### PR TITLE
Connect frontend to backend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zettelkasten Front
 
-This repository contains the front-end of the Zettelkasten project. It will be built using **Angular**. The REST API and other backend logic live in a separate repository.
+This repository contains the front-end of the Zettelkasten project. It is built using **AngularJS** and communicates with the REST API provided by the backend service.
 
 ## Project Status
 
@@ -10,7 +10,8 @@ The project is at its initial stage. More information will be added as developme
 
 1. Clone this repository.
 2. Install dependencies after setting up your Angular environment.
-3. Run the Angular development server.
+3. Run the development server.
+4. Ensure the backend API is running (by default at `http://localhost:8000`).
 
 ```
 # Example steps
@@ -19,4 +20,15 @@ ng serve
 ```
 
 The backend is expected to run separately. Check the backend repository for details.
+The front-end expects the following note endpoints to be available:
+
+```
+POST   /notes
+GET    /notes
+GET    /notes/{note_id}
+PUT    /notes/{note_id}
+DELETE /notes/{note_id}
+```
+
+Update the `API_BASE` variable in `app.js` if your backend runs on a different URL.
 

--- a/index.html
+++ b/index.html
@@ -15,14 +15,14 @@
       <button type="submit">Add Note</button>
     </form>
     <div class="notes">
-      <div class="note" ng-repeat="note in ctrl.notes track by $index">
+      <div class="note" ng-repeat="note in ctrl.notes track by note.id">
         <h2>{{note.title}}</h2>
         <p>{{note.content}}</p>
-        <button ng-click="ctrl.editNote($index)">Edit</button>
-        <button ng-click="ctrl.deleteNote($index)">Delete</button>
+        <button ng-click="ctrl.editNote(note)">Edit</button>
+        <button ng-click="ctrl.deleteNote(note)">Delete</button>
       </div>
     </div>
-    <div class="edit-section" ng-if="ctrl.editing >= 0">
+    <div class="edit-section" ng-if="ctrl.editing">
       <h2>Edit Note</h2>
       <form ng-submit="ctrl.updateNote()">
         <input type="text" ng-model="ctrl.editNoteData.title" required>


### PR DESCRIPTION
## Summary
- remove local storage usage and call REST API instead
- update notes list in index.html to use note.id and new functions
- document API expectations in README
- ignore `node_modules` and npm lock file

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688a3a7d54c0832da6e5ddd829baee05