### PR TITLE
Fix note ID usage for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The project is at its initial stage. More information will be added as developme
 
 1. Clone this repository.
 2. Install dependencies after setting up your Angular environment.
-3. Run the development server.
-4. Ensure the backend API is running (by default at `http://localhost:8000`).
+3. Run the development server (serves the front-end at `http://localhost:8000`).
+4. Ensure the backend API is running (by default at `http://localhost:3000`).
 
 ```
 # Example steps

--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@
     };
 
     self.deleteNote = function(note) {
-      $http.delete(API_BASE + '/' + note.id).then(function() {
+      $http.delete(API_BASE + '/' + note._id).then(function() {
         var index = self.notes.indexOf(note);
         if (index >= 0) {
           self.notes.splice(index, 1);
@@ -38,7 +38,7 @@
     };
 
     self.updateNote = function() {
-      $http.put(API_BASE + '/' + self.editing.id, self.editNoteData).then(function(res) {
+      $http.put(API_BASE + '/' + self.editing._id, self.editNoteData).then(function(res) {
         var index = self.notes.indexOf(self.editing);
         if (index >= 0) {
           self.notes[index] = res.data;

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <button type="submit">Add Note</button>
     </form>
     <div class="notes">
-      <div class="note" ng-repeat="note in ctrl.notes track by note.id">
+      <div class="note" ng-repeat="note in ctrl.notes track by note._id">
         <h2>{{note.title}}</h2>
         <p>{{note.content}}</p>
         <button ng-click="ctrl.editNote(note)">Edit</button>


### PR DESCRIPTION
## Summary
- use `_id` from backend responses for update and delete actions
- track notes by `_id` in Angular template

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a3eb201a4832d9f0c0693f15255e3