### PR TITLE
feat: add login page and relocate notes app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The project is at its initial stage. More information will be added as developme
 
 1. Clone this repository.
 2. Install dependencies after setting up your Angular environment.
-3. Run the development server (serves the front-end at `http://localhost:8000`).
+3. Run the development server (serves the front-end at `http://localhost:8000`). Visit `http://localhost:8000/` for the login page and `http://localhost:8000/notes/` for notes.
 4. Ensure the backend API is running (by default at `http://localhost:3000`).
 
 ```

--- a/index.html
+++ b/index.html
@@ -1,37 +1,24 @@
 <!doctype html>
-<html lang="en" ng-app="notesApp">
+<html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Zettelkasten Notes</title>
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
+  <title>Login - Zettelkasten</title>
   <link rel="stylesheet" href="style.css">
+  <script>
+    function login(event) {
+      event.preventDefault();
+      window.location.href = '/notes/';
+    }
+  </script>
 </head>
-<body ng-controller="NotesController as ctrl">
+<body>
   <div class="container">
-    <h1>Zettelkasten Notes</h1>
-    <form ng-submit="ctrl.addNote()">
-      <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
-      <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>
-      <button type="submit">Add Note</button>
+    <h1>Login</h1>
+    <form onsubmit="login(event)">
+      <input type="text" placeholder="Username" required>
+      <input type="password" placeholder="Password" required>
+      <button type="submit">Login</button>
     </form>
-    <div class="notes">
-      <div class="note" ng-repeat="note in ctrl.notes track by note._id">
-        <h2>{{note.title}}</h2>
-        <p>{{note.content}}</p>
-        <button ng-click="ctrl.editNote(note)">Edit</button>
-        <button ng-click="ctrl.deleteNote(note)">Delete</button>
-      </div>
-    </div>
-    <div class="edit-section" ng-if="ctrl.editing">
-      <h2>Edit Note</h2>
-      <form ng-submit="ctrl.updateNote()">
-        <input type="text" ng-model="ctrl.editNoteData.title" required>
-        <textarea ng-model="ctrl.editNoteData.content" required></textarea>
-        <button type="submit">Save</button>
-        <button type="button" ng-click="ctrl.cancelEdit()">Cancel</button>
-      </form>
-    </div>
   </div>
-  <script src="app.js"></script>
 </body>
 </html>

--- a/notes/index.html
+++ b/notes/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en" ng-app="notesApp">
+<head>
+  <meta charset="utf-8">
+  <title>Zettelkasten Notes</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body ng-controller="NotesController as ctrl">
+  <div class="container">
+    <h1>Zettelkasten Notes</h1>
+    <form ng-submit="ctrl.addNote()">
+      <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
+      <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>
+      <button type="submit">Add Note</button>
+    </form>
+    <div class="notes">
+      <div class="note" ng-repeat="note in ctrl.notes track by note._id">
+        <h2>{{note.title}}</h2>
+        <p>{{note.content}}</p>
+        <button ng-click="ctrl.editNote(note)">Edit</button>
+        <button ng-click="ctrl.deleteNote(note)">Delete</button>
+      </div>
+    </div>
+    <div class="edit-section" ng-if="ctrl.editing">
+      <h2>Edit Note</h2>
+      <form ng-submit="ctrl.updateNote()">
+        <input type="text" ng-model="ctrl.editNoteData.title" required>
+        <textarea ng-model="ctrl.editNoteData.content" required></textarea>
+        <button type="submit">Save</button>
+        <button type="button" ng-click="ctrl.cancelEdit()">Cancel</button>
+      </form>
+    </div>
+  </div>
+  <script src="../app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add root login page that redirects to `/notes/`
- move existing notes UI into `/notes/` directory
- document new routes in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688adc710cec832db47bc947562ac9f2