### PR TITLE
Add login verification via backend endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm start
 ```
 
 The backend is expected to run separately. Check the backend repository for details.
+The login page posts credentials to `POST /users/verify` and redirects to the notes section on success.
 The front-end expects the following note endpoints to be available:
 
 ```

--- a/index.html
+++ b/index.html
@@ -7,7 +7,29 @@
   <script>
     function login(event) {
       event.preventDefault();
-      window.location.href = '/notes/';
+      const username = document.getElementById('username').value;
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+
+      fetch('http://localhost:3000/users/verify', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ username, email, password })
+      })
+      .then(function(res) {
+        if (res.ok) {
+          window.location.href = '/notes/';
+        } else {
+          return res.json().then(function(data) {
+            throw new Error(data.detail || 'Login failed');
+          });
+        }
+      })
+      .catch(function(err) {
+        document.getElementById('error').textContent = err.message;
+      });
     }
   </script>
 </head>
@@ -15,9 +37,11 @@
   <div class="container">
     <h1>Login</h1>
     <form onsubmit="login(event)">
-      <input type="text" placeholder="Username" required>
-      <input type="password" placeholder="Password" required>
+      <input type="text" id="username" placeholder="Username" required>
+      <input type="email" id="email" placeholder="Email" required>
+      <input type="password" id="password" placeholder="Password" required>
       <button type="submit">Login</button>
+      <p id="error" class="error"></p>
     </form>
   </div>
 </body>

--- a/style.css
+++ b/style.css
@@ -14,7 +14,10 @@ body {
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-form input[type="text"], form textarea {
+form input[type="text"],
+form input[type="email"],
+form input[type="password"],
+form textarea {
     width: 100%;
     padding: 10px;
     margin-bottom: 10px;
@@ -25,6 +28,10 @@ form input[type="text"], form textarea {
 
 button {
     margin-right: 10px;
+}
+
+.error {
+    color: red;
 }
 
 .notes {


### PR DESCRIPTION
## Summary
- Verify user credentials by posting login form data to `/users/verify`
- Style email/password inputs and show error messages
- Document login verification endpoint in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688aeb54b490832db5eced758e77b215