### PR TITLE
Add basic session logic to protect notes page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8">
   <title>Login - Zettelkasten</title>
   <link rel="stylesheet" href="style.css">
+  <script src="session.js"></script>
+  <script>
+    auth.redirectIfAuthenticated();
+  </script>
   <script>
     function login(event) {
       event.preventDefault();
@@ -19,13 +23,16 @@
         body: JSON.stringify({ username, email, password })
       })
       .then(function(res) {
-        if (res.ok) {
-          window.location.href = '/notes/';
-        } else {
+        if (!res.ok) {
           return res.json().then(function(data) {
             throw new Error(data.detail || 'Login failed');
           });
         }
+        return res.json();
+      })
+      .then(function(data) {
+        auth.login(data.token || 'logged');
+        window.location.href = '/notes/';
       })
       .catch(function(err) {
         document.getElementById('error').textContent = err.message;

--- a/notes/index.html
+++ b/notes/index.html
@@ -4,11 +4,16 @@
   <meta charset="utf-8">
   <title>Zettelkasten Notes</title>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
+  <script src="../session.js"></script>
+  <script>
+    auth.requireAuth();
+  </script>
   <link rel="stylesheet" href="../style.css">
 </head>
 <body ng-controller="NotesController as ctrl">
   <div class="container">
     <h1>Zettelkasten Notes</h1>
+    <button onclick="auth.logout()">Logout</button>
     <form ng-submit="ctrl.addNote()">
       <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
       <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>

--- a/session.js
+++ b/session.js
@@ -1,0 +1,26 @@
+(function() {
+  const STORAGE_KEY = 'authToken';
+
+  window.auth = {
+    login(token) {
+      localStorage.setItem(STORAGE_KEY, token);
+    },
+    logout() {
+      localStorage.removeItem(STORAGE_KEY);
+      window.location.href = '/';
+    },
+    isLoggedIn() {
+      return !!localStorage.getItem(STORAGE_KEY);
+    },
+    requireAuth() {
+      if (!this.isLoggedIn()) {
+        window.location.href = '/';
+      }
+    },
+    redirectIfAuthenticated() {
+      if (this.isLoggedIn()) {
+        window.location.href = '/notes/';
+      }
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
- Implement simple localStorage-based auth helper
- Gate the notes page behind authentication and add logout button
- Store auth token on login and redirect authenticated users

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688b6efcfc1c832da581cdade3925ce5