### PR TITLE
Pass user_id to note creation and updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,8 @@
     };
 
     self.addNote = function() {
-      $http.post(API_BASE, self.newNote).then(function(res) {
+      var url = API_BASE + '?user_id=' + auth.getUserId();
+      $http.post(url, self.newNote).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};
       });
@@ -38,7 +39,8 @@
     };
 
     self.updateNote = function() {
-      $http.put(API_BASE + '/' + self.editing._id, self.editNoteData).then(function(res) {
+      var url = API_BASE + '/' + self.editing._id + '?user_id=' + auth.getUserId();
+      $http.put(url, self.editNoteData).then(function(res) {
         var index = self.notes.indexOf(self.editing);
         if (index >= 0) {
           self.notes[index] = res.data;

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         return res.json();
       })
       .then(function(data) {
-        auth.login(data.token || 'logged');
+        auth.login(data.token || 'logged', data.user_id);
         window.location.href = '/notes/';
       })
       .catch(function(err) {

--- a/session.js
+++ b/session.js
@@ -1,16 +1,24 @@
 (function() {
-  const STORAGE_KEY = 'authToken';
+  const TOKEN_KEY = 'authToken';
+  const USER_ID_KEY = 'userId';
 
   window.auth = {
-    login(token) {
-      localStorage.setItem(STORAGE_KEY, token);
+    login(token, userId) {
+      localStorage.setItem(TOKEN_KEY, token);
+      if (userId) {
+        localStorage.setItem(USER_ID_KEY, userId);
+      }
     },
     logout() {
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(USER_ID_KEY);
       window.location.href = '/';
     },
     isLoggedIn() {
-      return !!localStorage.getItem(STORAGE_KEY);
+      return !!localStorage.getItem(TOKEN_KEY);
+    },
+    getUserId() {
+      return localStorage.getItem(USER_ID_KEY);
     },
     requireAuth() {
       if (!this.isLoggedIn()) {


### PR DESCRIPTION
## Summary
- Store user ID in session storage and expose helper to retrieve it
- Save user_id on login and include it when creating or updating notes

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688b9f15f968832d9fe809947fc01103