### PR TITLE
Ensure user ID is sent with note requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,8 +17,10 @@
     };
 
     self.addNote = function() {
-      var url = API_BASE + '?user_id=' + auth.getUserId();
-      $http.post(url, self.newNote).then(function(res) {
+      var noteData = angular.extend({}, self.newNote, {
+        user_id: auth.getUserId()
+      });
+      $http.post(API_BASE, noteData).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};
       });
@@ -39,8 +41,11 @@
     };
 
     self.updateNote = function() {
-      var url = API_BASE + '/' + self.editing._id + '?user_id=' + auth.getUserId();
-      $http.put(url, self.editNoteData).then(function(res) {
+      var url = API_BASE + '/' + self.editing._id;
+      var noteData = angular.extend({}, self.editNoteData, {
+        user_id: auth.getUserId()
+      });
+      $http.put(url, noteData).then(function(res) {
         var index = self.notes.indexOf(self.editing);
         if (index >= 0) {
           self.notes[index] = res.data;


### PR DESCRIPTION
## Summary
- include logged in user ID in new note requests
- include logged in user ID in note update requests

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688ba446559c832da34889d384d8cb4c