### PR TITLE
fix: persist user id for note creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
         return res.json();
       })
       .then(function(data) {
-        auth.login(data.token || 'logged', data.user_id);
+        var userId = data.user_id || data.userId || data.id;
+        auth.login(data.token || 'logged', userId);
         window.location.href = '/notes/';
       })
       .catch(function(err) {

--- a/session.js
+++ b/session.js
@@ -5,7 +5,7 @@
   window.auth = {
     login(token, userId) {
       localStorage.setItem(TOKEN_KEY, token);
-      if (userId) {
+      if (userId !== undefined && userId !== null) {
         localStorage.setItem(USER_ID_KEY, userId);
       }
     },
@@ -15,14 +15,17 @@
       window.location.href = '/';
     },
     isLoggedIn() {
-      return !!localStorage.getItem(TOKEN_KEY);
+      return (
+        !!localStorage.getItem(TOKEN_KEY) &&
+        !!localStorage.getItem(USER_ID_KEY)
+      );
     },
     getUserId() {
       return localStorage.getItem(USER_ID_KEY);
     },
     requireAuth() {
       if (!this.isLoggedIn()) {
-        window.location.href = '/';
+        this.logout();
       }
     },
     redirectIfAuthenticated() {


### PR DESCRIPTION
## Summary
- ensure login persists user id from auth response
- require both token and user id for session auth

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ba6b289f8832da47df8079fd9a923