### PR TITLE
fix: handle backend redirects and user ID

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@
 
   app.controller('NotesController', function($http) {
     var self = this;
-    var API_BASE = 'http://localhost:3000/notes';
+    var API_BASE = 'http://localhost:3000/notes/';
 
     self.notes = [];
     self.newNote = {};
@@ -27,7 +27,7 @@
     };
 
     self.deleteNote = function(note) {
-      $http.delete(API_BASE + '/' + note._id).then(function() {
+      $http.delete(API_BASE + note._id).then(function() {
         var index = self.notes.indexOf(note);
         if (index >= 0) {
           self.notes.splice(index, 1);
@@ -41,7 +41,7 @@
     };
 
     self.updateNote = function() {
-      var url = API_BASE + '/' + self.editing._id;
+      var url = API_BASE + self.editing._id;
       var noteData = angular.extend({}, self.editNoteData, {
         user_id: auth.getUserId()
       });

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
       })
       .then(function(data) {
         var userId = data.user_id || data.userId || data.id;
+        if (!userId && data.user) {
+          userId = data.user.user_id || data.user.userId || data.user.id || data.user._id;
+        }
         auth.login(data.token || 'logged', userId);
         window.location.href = '/notes/';
       })


### PR DESCRIPTION
## Summary
- avoid CORS redirect by using trailing slash for notes API and cleaned up CRUD URLs
- persist user ID from nested fields in login response to prevent null `user_id`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ba97e6d90832dab1f756d3ab0f25a