### PR TITLE
Fix redirects to avoid hardcoded localhost

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@
         if (!userId && data.user) {
           userId = data.user.user_id || data.user.userId || data.user.id || data.user._id;
         }
-        auth.login(data.token || 'logged', userId);
-        window.location.href = '/notes/';
+          auth.login(data.token || 'logged', userId);
+          auth.redirectToNotes();
       })
       .catch(function(err) {
         document.getElementById('error').textContent = err.message;
@@ -60,7 +60,7 @@
       <input type="email" id="email" placeholder="Email" required>
       <input type="password" id="password" placeholder="Password" required>
       <button type="submit">Login</button>
-      <button type="button" onclick="window.location.href='/register/'">Register</button>
+        <button type="button" onclick="window.location.href = auth.basePath() + 'register/'">Register</button>
       <p id="error" class="error"></p>
     </form>
   </div>

--- a/register/index.html
+++ b/register/index.html
@@ -30,9 +30,9 @@
         }
         return res.json();
       })
-      .then(function() {
-        window.location.href = '/';
-      })
+        .then(function() {
+          window.location.href = auth.basePath();
+        })
       .catch(function(err) {
         document.getElementById('error').textContent = err.message;
       });

--- a/session.js
+++ b/session.js
@@ -2,7 +2,17 @@
   const TOKEN_KEY = 'authToken';
   const USER_ID_KEY = 'userId';
 
+  // Determine the base path of the application so that redirects work when the
+  // app is served from a subdirectory.
+  function getBasePath() {
+    const parts = window.location.pathname.split('/').filter(function(p) {
+      return p;
+    });
+    return parts.length > 0 ? '/' + parts[0] + '/' : '/';
+  }
+
   window.auth = {
+    basePath: getBasePath,
     login(token, userId) {
       localStorage.setItem(TOKEN_KEY, token);
       if (userId !== undefined && userId !== null) {
@@ -12,7 +22,7 @@
     logout() {
       localStorage.removeItem(TOKEN_KEY);
       localStorage.removeItem(USER_ID_KEY);
-      window.location.href = '/';
+      window.location.href = getBasePath();
     },
     isLoggedIn() {
       return (
@@ -28,9 +38,12 @@
         this.logout();
       }
     },
+    redirectToNotes() {
+      window.location.href = getBasePath() + 'notes/';
+    },
     redirectIfAuthenticated() {
       if (this.isLoggedIn()) {
-        window.location.href = '/notes/';
+        this.redirectToNotes();
       }
     }
   };


### PR DESCRIPTION
## Summary
- compute application base path dynamically and centralize redirect helpers
- use new helpers in login and registration pages to navigate without hardcoded localhost

## Testing
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_688bb7fd31b0832d83e0360c578844b2