### PR TITLE
Fix base path calculation to prevent redirect loop

### DIFF
--- a/session.js
+++ b/session.js
@@ -5,10 +5,15 @@
   // Determine the base path of the application so that redirects work when the
   // app is served from a subdirectory.
   function getBasePath() {
-    const parts = window.location.pathname.split('/').filter(function(p) {
-      return p;
-    });
-    return parts.length > 0 ? '/' + parts[0] + '/' : '/';
+    const parts = window.location.pathname
+      .split('/')
+      .filter(function(p) {
+        return p;
+      });
+    if (parts.length > 0 && ['notes', 'register'].includes(parts[parts.length - 1])) {
+      parts.pop();
+    }
+    return '/' + parts.join('/') + (parts.length > 0 ? '/' : '');
   }
 
   window.auth = {


### PR DESCRIPTION
## Summary
- Correct base path detection so redirects from nested pages (e.g., notes, register) return to the application root

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688bb9cfec58832da6ba857936f8c8ff