### PR TITLE
fix: correct base path handling

### DIFF
--- a/session.js
+++ b/session.js
@@ -10,7 +10,10 @@
       .filter(function(p) {
         return p;
       });
-    if (parts.length > 0 && ['notes', 'register'].includes(parts[parts.length - 1])) {
+    if (
+      parts.length > 0 &&
+      ['notes', 'register', 'index.html'].includes(parts[parts.length - 1])
+    ) {
       parts.pop();
     }
     return '/' + parts.join('/') + (parts.length > 0 ? '/' : '');


### PR DESCRIPTION
## Summary
- remove `index.html` from base path calculations to stop unwanted redirects to the site's root

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_688bbb226e28832d9d23b85ff5fe5f80