### PR TITLE
fix: redirect authenticated users to notes

### DIFF
--- a/session.js
+++ b/session.js
@@ -47,7 +47,9 @@
       }
     },
     redirectToNotes() {
-      window.location.href = getBasePath() + 'notes/';
+      // Always send the user to the notes page served from the front-end
+      // development server running on port 8000.
+      window.location.href = 'http://localhost:8000/notes';
     },
     redirectIfAuthenticated() {
       if (this.isLoggedIn()) {


### PR DESCRIPTION
## Summary
- ensure login success takes users to http://localhost:8000/notes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688bbc9fe144832d92c243df321c6caa