### PR TITLE
guard note actions behind auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,11 +17,13 @@
     };
 
     self.addNote = function() {
-      var noteData = angular.copy(self.newNote);
       var userId = auth.getUserId();
-      if (userId) {
-        noteData.user_id = userId;
+      if (!userId) {
+        auth.requireAuth();
+        return;
       }
+      var noteData = angular.copy(self.newNote);
+      noteData.user_id = userId;
       $http.post(API_BASE, noteData).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};
@@ -29,6 +31,11 @@
     };
 
     self.deleteNote = function(note) {
+      var userId = auth.getUserId();
+      if (!userId) {
+        auth.requireAuth();
+        return;
+      }
       $http.delete(API_BASE + note._id).then(function() {
         var index = self.notes.indexOf(note);
         if (index >= 0) {
@@ -43,12 +50,14 @@
     };
 
     self.updateNote = function() {
+      var userId = auth.getUserId();
+      if (!userId) {
+        auth.requireAuth();
+        return;
+      }
       var url = API_BASE + self.editing._id;
       var noteData = angular.copy(self.editNoteData);
-      var userId = auth.getUserId();
-      if (userId) {
-        noteData.user_id = userId;
-      }
+      noteData.user_id = userId;
       $http.put(url, noteData).then(function(res) {
         var index = self.notes.indexOf(self.editing);
         if (index >= 0) {

--- a/notes/index.html
+++ b/notes/index.html
@@ -11,7 +11,7 @@
   <div class="container">
     <h1>Zettelkasten Notes</h1>
     <button ng-if="auth.isLoggedIn()" onclick="auth.logout()">Logout</button>
-    <form ng-submit="ctrl.addNote()">
+    <form ng-if="auth.isLoggedIn()" ng-submit="ctrl.addNote()">
       <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
       <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>
       <button type="submit">Add Note</button>
@@ -20,11 +20,11 @@
       <div class="note" ng-repeat="note in ctrl.notes track by note._id">
         <h2>{{note.title}}</h2>
         <p>{{note.content}}</p>
-        <button ng-click="ctrl.editNote(note)">Edit</button>
-        <button ng-click="ctrl.deleteNote(note)">Delete</button>
+        <button ng-if="auth.isLoggedIn()" ng-click="ctrl.editNote(note)">Edit</button>
+        <button ng-if="auth.isLoggedIn()" ng-click="ctrl.deleteNote(note)">Delete</button>
       </div>
     </div>
-    <div class="edit-section" ng-if="ctrl.editing">
+    <div class="edit-section" ng-if="ctrl.editing && auth.isLoggedIn()">
       <h2>Edit Note</h2>
       <form ng-submit="ctrl.updateNote()">
         <input type="text" ng-model="ctrl.editNoteData.title" required>


### PR DESCRIPTION
## Summary
- prevent missing `user_id` errors by requiring login before note creation, updates, and deletions
- show note creation and edit controls only when authenticated

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688bbf734bf4832db80b93a7dea27068