### PR TITLE
Redirect unauthenticated visitors from notes page to login

### DIFF
--- a/notes/index.html
+++ b/notes/index.html
@@ -5,6 +5,7 @@
   <title>Zettelkasten Notes</title>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
   <script src="../session.js"></script>
+  <script>auth.requireAuth();</script>
   <link rel="stylesheet" href="../style.css">
 </head>
 <body ng-controller="NotesController as ctrl">


### PR DESCRIPTION
## Summary
- Ensure the notes view checks for authentication on load and redirects to the login page when the user isn't authenticated

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688bc14b9924832d926ec476d74fcfd2