### PR TITLE
Ensure notes refresh after creation

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,9 @@
       $http.post(API_BASE, noteData).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};
+        self.loadNotes();
+      }, function(err) {
+        console.error('Failed to add note', err);
       });
     };
 


### PR DESCRIPTION
## Summary
- reload notes from the API after a note is created to display the new entry
- log an error when adding a note fails

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bc3b299f8832dbc1ac0bb99df776d