### PR TITLE
Ensure user ID is included when sending note data

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@
 
     self.addNote = function() {
       var noteData = angular.copy(self.newNote);
+      noteData.userId = localStorage.getItem('userId');
       $http.post(API_BASE, noteData).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};
@@ -44,6 +45,7 @@
     self.updateNote = function() {
       var url = API_BASE + self.editing._id;
       var noteData = angular.copy(self.editNoteData);
+      noteData.userId = localStorage.getItem('userId');
       $http.put(url, noteData).then(function(res) {
         var index = self.notes.indexOf(self.editing);
         if (index >= 0) {


### PR DESCRIPTION
## Summary
- attach `userId` from `localStorage` to note creation and updates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bc57147d8832d90e03143edd63829