### PR TITLE
Use fixed user id for new notes

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@
   app.controller('NotesController', function($http) {
     var self = this;
     var API_BASE = 'http://localhost:3000/notes/';
+    var FIXED_USER_ID = '688bbae65143456fad9ed526';
 
     self.notes = [];
     self.newNote = {};
@@ -18,7 +19,7 @@
 
     self.addNote = function() {
       var noteData = angular.copy(self.newNote);
-      noteData.userId = localStorage.getItem('userId');
+      noteData.userId = FIXED_USER_ID;
       $http.post(API_BASE, noteData).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};


### PR DESCRIPTION
## Summary
- assign a constant user id to new notes in the Angular front-end

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bc7ba595c832d91144c6802610df5