### PR TITLE
Use fixed user_id for note requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@
   app.controller('NotesController', function($http) {
     var self = this;
     var API_BASE = 'http://localhost:3000/notes/';
+    var USER_ID = '688bbae65143456fad9ed526';
 
     self.notes = [];
     self.newNote = {};
@@ -18,7 +19,7 @@
 
     self.addNote = function() {
       var noteData = angular.copy(self.newNote);
-      noteData.userId = localStorage.getItem('userId');
+      noteData.user_id = USER_ID;
       $http.post(API_BASE, noteData).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};
@@ -45,7 +46,7 @@
     self.updateNote = function() {
       var url = API_BASE + self.editing._id;
       var noteData = angular.copy(self.editNoteData);
-      noteData.userId = localStorage.getItem('userId');
+      noteData.user_id = USER_ID;
       $http.put(url, noteData).then(function(res) {
         var index = self.notes.indexOf(self.editing);
         if (index >= 0) {


### PR DESCRIPTION
## Summary
- hardcode backend's expected user_id when creating or updating notes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bcb4e8394832d9a541995efcda5ab