### PR TITLE
Ensure userId is populated for notes

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@
 
     self.addNote = function() {
       var noteData = angular.copy(self.newNote);
-      noteData.user_id = USER_ID;
+      noteData.userId = USER_ID;
       $http.post(API_BASE, noteData).then(function(res) {
         self.notes.push(res.data);
         self.newNote = {};
@@ -46,7 +46,7 @@
     self.updateNote = function() {
       var url = API_BASE + self.editing._id;
       var noteData = angular.copy(self.editNoteData);
-      noteData.user_id = USER_ID;
+      noteData.userId = USER_ID;
       $http.put(url, noteData).then(function(res) {
         var index = self.notes.indexOf(self.editing);
         if (index >= 0) {


### PR DESCRIPTION
## Summary
- populate `userId` with fixed ID when creating or updating notes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bd675d450832da4ed20147c03b55c