### PR TITLE
List notes on root page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The project is at its initial stage. More information will be added as developme
 
 1. Clone this repository.
 2. Install dependencies after setting up your Angular environment.
-3. Run the development server (serves the front-end at `http://localhost:8000`). Visit `http://localhost:8000/` for the login page and `http://localhost:8000/notes/` for notes.
+3. Run the development server (serves the front-end at `http://localhost:8000`) which lists notes pulled from `http://localhost:3000/notes`.
 4. Ensure the backend API is running (by default at `http://localhost:3000`).
 
 ```
@@ -20,7 +20,6 @@ npm start
 ```
 
 The backend is expected to run separately. Check the backend repository for details.
-The login page posts credentials to `POST /users/verify` and redirects to the notes section on success.
 The front-end expects the following note endpoints to be available:
 
 ```

--- a/index.html
+++ b/index.html
@@ -1,14 +1,21 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" ng-app="notesApp">
 <head>
   <meta charset="utf-8">
   <title>Zettelkasten</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body ng-controller="NotesController as ctrl">
   <div class="container">
     <h1>Zettelkasten</h1>
-    <a href="notes/">Go to Notes</a>
+    <div class="notes">
+      <div class="note" ng-repeat="note in ctrl.notes track by note._id">
+        <h2>{{note.title}}</h2>
+        <p>{{note.content}}</p>
+      </div>
+    </div>
   </div>
+  <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Display notes from backend on home page using Angular
- Update README to mention notes listing at root and backend endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bee3682c0832daf754cc19694577b