### PR TITLE
Add basic login validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The project is at its initial stage. More information will be added as developme
 
 1. Clone this repository.
 2. Install dependencies after setting up your Angular environment.
-3. Run the development server (serves the front-end at `http://localhost:8000`). Visit `http://localhost:8000/` for the login page and `http://localhost:8000/notes/` for notes.
+3. Run the development server (serves the front-end at `http://localhost:8000`). Visit `http://localhost:8000/` for the login page and `http://localhost:8000/notes/` for notes. Use the default credentials **admin/password** to log in.
 4. Ensure the backend API is running (by default at `http://localhost:3000`).
 
 ```

--- a/index.html
+++ b/index.html
@@ -7,7 +7,15 @@
   <script>
     function login(event) {
       event.preventDefault();
-      window.location.href = '/notes/';
+      var username = document.getElementById('username').value.trim();
+      var password = document.getElementById('password').value.trim();
+      var error = document.getElementById('error');
+      error.textContent = '';
+      if (username === 'admin' && password === 'password') {
+        window.location.href = '/notes/';
+      } else {
+        error.textContent = 'Invalid username or password.';
+      }
     }
   </script>
 </head>
@@ -15,9 +23,10 @@
   <div class="container">
     <h1>Login</h1>
     <form onsubmit="login(event)">
-      <input type="text" placeholder="Username" required>
-      <input type="password" placeholder="Password" required>
+      <input id="username" type="text" placeholder="Username" required>
+      <input id="password" type="password" placeholder="Password" required>
       <button type="submit">Login</button>
+      <div id="error" class="error"></div>
     </form>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add client-side validation to login page and show error for invalid credentials
- document default login credentials in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688cc360055c832d88535a0a5696ac90