### PR TITLE
feat: validate user via backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,11 @@
   app.controller('NotesController', function($http) {
     var self = this;
     var API_BASE = 'http://localhost:3000/notes/';
-    var USER_ID = '688bbae65143456fad9ed526';
+    var USER_ID = localStorage.getItem('userId');
+    if (!USER_ID) {
+      window.location.href = '/';
+      return;
+    }
 
     self.notes = [];
     self.newNote = {};

--- a/index.html
+++ b/index.html
@@ -11,11 +11,25 @@
       var password = document.getElementById('password').value.trim();
       var error = document.getElementById('error');
       error.textContent = '';
-      if (username === 'admin' && password === 'password') {
+      fetch('http://localhost:3000/users/verify', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ username: username, password: password })
+      }).then(function(res) {
+        if (res.ok) {
+          return res.json();
+        }
+        return res.json().then(function(data) {
+          throw new Error(data.detail || 'Invalid username or password.');
+        });
+      }).then(function(user) {
+        localStorage.setItem('userId', user._id);
         window.location.href = '/notes/';
-      } else {
-        error.textContent = 'Invalid username or password.';
-      }
+      }).catch(function(err) {
+        error.textContent = err.message;
+      });
     }
   </script>
 </head>


### PR DESCRIPTION
## Summary
- validate login via `/users/verify` endpoint
- persist user id and use it for note requests

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688cc5126078832d9c2bbd87903ce310