### PR TITLE
Add user sign up page and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       <input id="username" type="text" placeholder="Username" required>
       <input id="password" type="password" placeholder="Password" required>
       <button type="submit">Login</button>
+      <button type="button" onclick="window.location.href='signup.html'">Sign Up</button>
       <div id="error" class="error"></div>
     </form>
   </div>

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Sign Up - Zettelkasten</title>
+  <link rel="stylesheet" href="style.css">
+  <script>
+    function signup(event) {
+      event.preventDefault();
+      var username = document.getElementById('username').value.trim();
+      var email = document.getElementById('email').value.trim();
+      var password = document.getElementById('password').value.trim();
+      var error = document.getElementById('error');
+      var success = document.getElementById('success');
+      error.textContent = '';
+      success.textContent = '';
+      fetch('http://localhost:3000/users/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ username: username, email: email, password: password })
+      }).then(function(res) {
+        if (res.ok) {
+          success.textContent = 'Account created! You can now log in.';
+          document.getElementById('username').value = '';
+          document.getElementById('email').value = '';
+          document.getElementById('password').value = '';
+        } else {
+          return res.json().then(function(data) {
+            throw new Error(data.detail || 'Failed to sign up.');
+          });
+        }
+      }).catch(function(err) {
+        error.textContent = err.message;
+      });
+    }
+  </script>
+</head>
+<body>
+  <div class="container">
+    <h1>Sign Up</h1>
+    <form onsubmit="signup(event)">
+      <input id="username" type="text" placeholder="Username" required>
+      <input id="email" type="email" placeholder="Email" required>
+      <input id="password" type="password" placeholder="Password" required>
+      <button type="submit">Sign Up</button>
+      <div id="error" class="error"></div>
+      <div id="success" class="success"></div>
+    </form>
+  </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -34,6 +34,10 @@ button {
     color: red;
 }
 
+.success {
+    color: green;
+}
+
 .notes {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add signup page that sends registration data to backend
- link login page to new signup page
- style success notifications

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688cc7b09354832da54f1a09a9573d52