### PR TITLE
Add logout button to notes page

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,6 +67,11 @@
       self.editNoteData = {};
     };
 
+    self.logout = function() {
+      localStorage.removeItem('userId');
+      window.location.href = '/';
+    };
+
     self.loadNotes();
   });
 })();

--- a/notes/index.html
+++ b/notes/index.html
@@ -9,6 +9,7 @@
 <body ng-controller="NotesController as ctrl">
   <div class="container">
     <h1>Zettelkasten Notes</h1>
+    <button type="button" ng-click="ctrl.logout()">Logout</button>
     <form ng-submit="ctrl.addNote()">
       <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
       <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>


### PR DESCRIPTION
## Summary
- add logout button to notes page to allow users to sign out
- implement logout handler that clears stored user id and redirects to login

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688d30a02460832d8a0155865be0e79c