### PR TITLE
feat: add ability to favorite notes

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@
   app.controller('NotesController', function($http) {
     var self = this;
     var API_BASE = 'http://localhost:3000/notes/';
+    var FAVORITES_API = 'http://localhost:3000/favorites/';
     var USER_ID = localStorage.getItem('userId');
     if (!USER_ID) {
       window.location.href = '/';
@@ -40,6 +41,15 @@
         if (index >= 0) {
           self.notes.splice(index, 1);
         }
+      });
+    };
+
+    self.favoriteNote = function(note) {
+      var payload = { userId: USER_ID, noteId: note._id };
+      $http.post(FAVORITES_API, payload).then(function() {
+        note.favorited = true;
+      }, function(err) {
+        console.error('Failed to favorite note', err);
       });
     };
 

--- a/notes/index.html
+++ b/notes/index.html
@@ -19,6 +19,7 @@
       <div class="note" ng-repeat="note in ctrl.notes track by note._id">
         <h2>{{note.title}}</h2>
         <p>{{note.content}}</p>
+        <button class="favorite-btn" ng-click="ctrl.favoriteNote(note)">{{note.favorited ? '★' : '☆'}}</button>
         <button ng-click="ctrl.editNote(note)">Edit</button>
         <button ng-click="ctrl.deleteNote(note)">Delete</button>
       </div>

--- a/style.css
+++ b/style.css
@@ -94,6 +94,19 @@ button:hover {
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
+.favorite-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    color: #ffcc00;
+    margin-right: 10px;
+}
+
+.favorite-btn:hover {
+    color: #ff9900;
+}
+
 .edit-section {
     margin-top: 30px;
     background-color: #f0f8ff;


### PR DESCRIPTION
## Summary
- add star icon to each note to allow favoriting
- call backend API to save favorite notes
- style favorite button with gold star appearance

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d404504dc832d9f979d9a1d4dc2f5