### PR TITLE
Load favorite notes on refresh

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,16 @@
     self.loadNotes = function() {
       $http.get(USER_NOTES_URL).then(function(res) {
         self.notes = res.data;
+        return $http.get(FAVORITES_API + USER_ID, {
+          headers: { accept: 'application/json' }
+        });
+      }).then(function(favRes) {
+        var favorites = favRes.data;
+        self.notes.forEach(function(note) {
+          note.favorited = favorites.some(function(fav) {
+            return fav.noteId === note._id;
+          });
+        });
       });
     };
 


### PR DESCRIPTION
## Summary
- Fetch user's favorite notes on page load and flag matching notes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d44b39b04832db6fe3570cb3597a1