### PR TITLE
feat: allow removing favorites

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,6 +63,14 @@
       });
     };
 
+    self.unfavoriteNote = function(note) {
+      $http.delete(FAVORITES_API + note._id).then(function() {
+        note.favorited = false;
+      }, function(err) {
+        console.error('Failed to remove favorite', err);
+      });
+    };
+
     self.editNote = function(note) {
       self.editing = note;
       self.editNoteData = angular.copy(note);

--- a/notes/index.html
+++ b/notes/index.html
@@ -19,7 +19,10 @@
       <div class="note" ng-repeat="note in ctrl.notes track by note._id">
         <h2>{{note.title}}</h2>
         <p>{{note.content}}</p>
-        <button class="favorite-btn" ng-click="ctrl.favoriteNote(note)">{{note.favorited ? '★' : '☆'}}</button>
+        <button class="favorite-btn"
+                ng-click="note.favorited ? ctrl.unfavoriteNote(note) : ctrl.favoriteNote(note)">
+          {{note.favorited ? '★' : '☆'}}
+        </button>
         <button ng-click="ctrl.editNote(note)">Edit</button>
         <button ng-click="ctrl.deleteNote(note)">Delete</button>
       </div>


### PR DESCRIPTION
## Summary
- support unfavoriting notes by calling DELETE /favorites/:note_id
- format favorite button markup

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688d487d5a18832db0971e833d21d111