### PR TITLE
Use popup for editing notes

### DIFF
--- a/notes/index.html
+++ b/notes/index.html
@@ -27,14 +27,16 @@
         <button ng-click="ctrl.deleteNote(note)">Delete</button>
       </div>
     </div>
-    <div class="edit-section" ng-if="ctrl.editing">
-      <h2>Edit Note</h2>
-      <form ng-submit="ctrl.updateNote()">
-        <input type="text" ng-model="ctrl.editNoteData.title" required>
-        <textarea ng-model="ctrl.editNoteData.content" required></textarea>
-        <button type="submit">Save</button>
-        <button type="button" ng-click="ctrl.cancelEdit()">Cancel</button>
-      </form>
+    <div class="modal" ng-if="ctrl.editing">
+      <div class="edit-section">
+        <h2>Edit Note</h2>
+        <form ng-submit="ctrl.updateNote()">
+          <input type="text" ng-model="ctrl.editNoteData.title" required>
+          <textarea ng-model="ctrl.editNoteData.content" required></textarea>
+          <button type="submit">Save</button>
+          <button type="button" ng-click="ctrl.cancelEdit()">Cancel</button>
+        </form>
+      </div>
     </div>
   </div>
   <script src="../app.js"></script>

--- a/style.css
+++ b/style.css
@@ -108,9 +108,20 @@ button:hover {
 }
 
 .edit-section {
-    margin-top: 30px;
     background-color: #f0f8ff;
     padding: 20px;
     border-radius: 8px;
     border: 1px solid #b3e6ff;
+}
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }


### PR DESCRIPTION
## Summary
- Show note edit form inside a popup modal
- Add styling for modal overlay and remove extra margin from edit section

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688d4e63d850832db9c72f69eb03bd8b