### PR TITLE
feat: add tag management sidebar

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@
     var self = this;
     var API_BASE = 'http://localhost:3000/notes/';
     var FAVORITES_API = 'http://localhost:3000/favorites/';
+    var TAGS_API = 'http://localhost:3000/tags/';
     var USER_ID = localStorage.getItem('userId');
     if (!USER_ID) {
       window.location.href = '/';
@@ -17,6 +18,9 @@
     self.adding = false;
     self.editing = null;
     self.editNoteData = {};
+    self.tags = [];
+    self.newTag = {};
+    self.addingTag = false;
     self.username = localStorage.getItem('username') || 'User';
 
     self.loadNotes = function() {
@@ -32,6 +36,12 @@
             return fav._id === note._id;
           });
         });
+      });
+    };
+
+    self.loadTags = function() {
+      $http.get(TAGS_API + 'user/' + USER_ID).then(function(res) {
+        self.tags = res.data;
       });
     };
 
@@ -55,6 +65,28 @@
         self.loadNotes();
       }, function(err) {
         console.error('Failed to add note', err);
+      });
+    };
+
+    self.openTagModal = function() {
+      self.addingTag = true;
+      self.newTag = {};
+    };
+
+    self.cancelTag = function() {
+      self.addingTag = false;
+      self.newTag = {};
+    };
+
+    self.addTag = function() {
+      var tagData = angular.copy(self.newTag);
+      tagData.userId = USER_ID;
+      $http.post(TAGS_API, tagData).then(function(res) {
+        self.tags.push(res.data);
+        self.newTag = {};
+        self.addingTag = false;
+      }, function(err) {
+        console.error('Failed to add tag', err);
       });
     };
 
@@ -114,5 +146,6 @@
     };
 
     self.loadNotes();
+    self.loadTags();
   });
 })();

--- a/notes/index.html
+++ b/notes/index.html
@@ -8,42 +8,65 @@
 </head>
 <body ng-controller="NotesController as ctrl">
   <button class="logout-btn" type="button" ng-click="ctrl.logout()">Logout</button>
-  <div class="container">
-    <h1>Hello {{ctrl.username}}</h1>
-    <button type="button" ng-click="ctrl.logout()">Logout</button>
-    <button type="button" ng-click="ctrl.openAddModal()">Add a new note</button>
-    <div class="notes">
-      <div class="note" ng-repeat="note in ctrl.notes track by note._id">
-        <h2>{{note.title}}</h2>
-        <p>{{note.content}}</p>
-        <button class="favorite-btn"
-                ng-click="note.favorited ? ctrl.unfavoriteNote(note) : ctrl.favoriteNote(note)">
-          {{note.favorited ? '★' : '☆'}}
-        </button>
-        <button ng-click="ctrl.editNote(note)">Edit</button>
-        <button ng-click="ctrl.deleteNote(note)">Delete</button>
-      </div>
+  <div class="page">
+    <div class="sidebar">
+      <h2>Tags</h2>
+      <ul>
+        <li ng-repeat="tag in ctrl.tags track by tag._id">{{tag.title}}</li>
+      </ul>
+      <button type="button" ng-click="ctrl.openTagModal()">Add Tag</button>
     </div>
-    <div class="modal" ng-if="ctrl.adding">
-      <div class="edit-section">
-        <h2>New Note</h2>
-        <form ng-submit="ctrl.addNote()">
-          <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
-          <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>
-          <button type="submit">Save</button>
-          <button type="button" ng-click="ctrl.cancelAdd()">Cancel</button>
-        </form>
+    <div class="container">
+      <h1>Hello {{ctrl.username}}</h1>
+      <button type="button" ng-click="ctrl.logout()">Logout</button>
+      <button type="button" ng-click="ctrl.openAddModal()">Add a new note</button>
+      <div class="notes">
+        <div class="note" ng-repeat="note in ctrl.notes track by note._id">
+          <h2>{{note.title}}</h2>
+          <p>{{note.content}}</p>
+          <button class="favorite-btn"
+                  ng-click="note.favorited ? ctrl.unfavoriteNote(note) : ctrl.favoriteNote(note)">
+            {{note.favorited ? '★' : '☆'}}
+          </button>
+          <button ng-click="ctrl.editNote(note)">Edit</button>
+          <button ng-click="ctrl.deleteNote(note)">Delete</button>
+        </div>
       </div>
-    </div>
-    <div class="modal" ng-if="ctrl.editing">
-      <div class="edit-section">
-        <h2>Edit Note</h2>
-        <form ng-submit="ctrl.updateNote()">
-          <input type="text" ng-model="ctrl.editNoteData.title" required>
-          <textarea ng-model="ctrl.editNoteData.content" required></textarea>
-          <button type="submit">Save</button>
-          <button type="button" ng-click="ctrl.cancelEdit()">Cancel</button>
-        </form>
+      <div class="modal" ng-if="ctrl.adding">
+        <div class="edit-section">
+          <h2>New Note</h2>
+          <form ng-submit="ctrl.addNote()">
+            <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
+            <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>
+            <button type="submit">Save</button>
+            <button type="button" ng-click="ctrl.cancelAdd()">Cancel</button>
+          </form>
+        </div>
+      </div>
+      <div class="modal" ng-if="ctrl.editing">
+        <div class="edit-section">
+          <h2>Edit Note</h2>
+          <form ng-submit="ctrl.updateNote()">
+            <input type="text" ng-model="ctrl.editNoteData.title" required>
+            <textarea ng-model="ctrl.editNoteData.content" required></textarea>
+            <button type="submit">Save</button>
+            <button type="button" ng-click="ctrl.cancelEdit()">Cancel</button>
+          </form>
+        </div>
+      </div>
+      <div class="modal" ng-if="ctrl.addingTag">
+        <div class="edit-section">
+          <h2>New Tag</h2>
+          <form ng-submit="ctrl.addTag()">
+            <input type="text" ng-model="ctrl.newTag.title" placeholder="Title" required>
+            <textarea ng-model="ctrl.newTag.description" placeholder="Description" required></textarea>
+            <select ng-model="ctrl.newTag.parent_note_id" required>
+              <option ng-repeat="note in ctrl.notes" value="{{note._id}}">{{note.title}}</option>
+            </select>
+            <button type="submit">Save</button>
+            <button type="button" ng-click="ctrl.cancelTag()">Cancel</button>
+          </form>
+        </div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -20,6 +20,35 @@ body {
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
 }
 
+.page {
+    display: flex;
+    width: 100%;
+    max-width: 1200px;
+}
+
+.sidebar {
+    width: 200px;
+    background: #ffffff;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    margin-right: 20px;
+    box-sizing: border-box;
+}
+
+.sidebar h2 {
+    margin-top: 0;
+}
+
+.sidebar ul {
+    list-style: none;
+    padding: 0;
+}
+
+.sidebar li {
+    margin-bottom: 10px;
+}
+
 h1 {
     text-align: center;
     margin-bottom: 30px;


### PR DESCRIPTION
## Summary
- add sidebar listing tags with ability to create new tag on notes page
- implement tag API integration and modal form with dropdown for parent note
- style sidebar and layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_688d9895a980832db905e590591c765a