### PR TITLE
Fetch user tags on notes page

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@
       return;
     }
     var USER_NOTES_URL = API_BASE + 'user/' + USER_ID;
+    var USER_TAGS_URL = TAGS_API + USER_ID;
 
     self.notes = [];
     self.newNote = {};
@@ -40,7 +41,7 @@
     };
 
     self.loadTags = function() {
-      $http.get(TAGS_API + 'user/' + USER_ID).then(function(res) {
+      $http.get(USER_TAGS_URL).then(function(res) {
         self.tags = res.data;
       });
     };


### PR DESCRIPTION
## Summary
- Retrieve tags from `http://localhost:3000/tags/{user_id}` when the notes page loads
- Expose user tags endpoint via `USER_TAGS_URL` for controller use

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d9dff5e88832dba54632597a9165a