### PR TITLE
Fix tag list tracking to use tag_id

### DIFF
--- a/notes/index.html
+++ b/notes/index.html
@@ -12,7 +12,7 @@
     <div class="sidebar">
       <h2>Tags</h2>
       <ul>
-        <li ng-repeat="tag in ctrl.tags track by tag._id">{{tag.title}}</li>
+        <li ng-repeat="tag in ctrl.tags track by tag.tag_id">{{tag.title}}</li>
       </ul>
       <button type="button" ng-click="ctrl.openTagModal()">Add Tag</button>
     </div>


### PR DESCRIPTION
## Summary
- ensure tags sidebar tracks by `tag_id` so tags remain visible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688da7b25cc4832d9335c2bf035b1091