### PR TITLE
Allow specifying parent note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,7 @@ PUT    /notes/{note_id}
 DELETE /notes/{note_id}
 ```
 
+Each note accepts an optional `note_parent_id` field to reference another note.
+
 Update the `API_BASE` variable in `app.js` if your backend runs on a different URL.
 

--- a/notes/index.html
+++ b/notes/index.html
@@ -40,6 +40,11 @@
           <form ng-submit="ctrl.addNote()">
             <input type="text" ng-model="ctrl.newNote.title" placeholder="Title" required>
             <textarea ng-model="ctrl.newNote.content" placeholder="Content" required></textarea>
+            <label for="parent-note-select">Parent Note</label>
+            <select ng-model="ctrl.newNote.note_parent_id">
+              <option value="">None</option>
+              <option ng-repeat="note in ctrl.notes track by note._id" value="{{note._id}}">{{note.title}}</option>
+            </select>
             <button type="submit">Save</button>
             <button type="button" ng-click="ctrl.cancelAdd()">Cancel</button>
           </form>
@@ -51,6 +56,11 @@
           <form ng-submit="ctrl.updateNote()">
             <input type="text" ng-model="ctrl.editNoteData.title" required>
             <textarea ng-model="ctrl.editNoteData.content" required></textarea>
+            <label for="edit-parent-note-select">Parent Note</label>
+            <select ng-model="ctrl.editNoteData.note_parent_id">
+              <option value="">None</option>
+              <option ng-repeat="note in ctrl.notes track by note._id" ng-if="note._id !== ctrl.editing._id" value="{{note._id}}">{{note.title}}</option>
+            </select>
             <button type="submit">Save</button>
             <button type="button" ng-click="ctrl.cancelEdit()">Cancel</button>
           </form>


### PR DESCRIPTION
## Summary
- add optional parent note selection when creating or editing notes
- document new `note_parent_id` field for note endpoints

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689015d4b320832da153d69fce1abffb